### PR TITLE
Only show diff-closures when /run/current-system exists.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,11 +50,13 @@
 
     activationDiffModule = { pkgs, config, ... }: {
       system.activationScripts.diffClosures.text = ''
-        echo "new configuration diff" >&2
-        $DRY_RUN_CMD ${pkgs.nixUnstable}/bin/nix store \
-            --experimental-features 'nix-command' \
-            diff-closures /run/current-system "$systemConfig" \
-            | sed -e 's/^/[diff]\t/' >&2
+        if [ -e /run/current-system ]; then
+          echo "new configuration diff" >&2
+          $DRY_RUN_CMD ${pkgs.nixUnstable}/bin/nix store \
+              --experimental-features 'nix-command' \
+              diff-closures /run/current-system "$systemConfig" \
+              | sed -e 's/^/[diff]\t/' >&2
+        fi
       '';
 
       system.activationScripts.preActivation.text =


### PR DESCRIPTION
On fist-time installations it's very likely that /run/current-system
is not already present. Since there's no currently installed nix-darwin
generation.

Fix #1