### PR TITLE
Make PATH include user&system bin on shell init.

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,1 +1,1 @@
-{ imports = [ ./activation-diff.nix ./intel-overlay.nix ]; }
+{ imports = [ ./activation-diff.nix ./intel-overlay.nix ./home-manager ]; }

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,0 +1,4 @@
+{
+  config.home-manager.sharedModules =
+    [ ./shared/fish.nix ./shared/zsh.nix ./shared/bash.nix ];
+}

--- a/modules/home-manager/shared/bash.nix
+++ b/modules/home-manager/shared/bash.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }:
+with lib;
+let
+  cfg = config.programs.bash;
+  username = config.home.username;
+
+  sysBin = "/nix/var/nix/profiles/default/bin";
+  usrBin =
+    "/nix/var/nix/profiles/per-user/${username}/home-manager/home-path/bin";
+
+in {
+  config = mkIf cfg.enable (mkMerge [
+
+    {
+      programs.bash.profileExtra = ''
+        case :$PATH: in
+          *:${sysBin}:*)  ;;  # do nothing
+          *) PATH=${sysBin}:$PATH ;;
+        esac
+        case :$PATH: in
+          *:${usrBin}:*)  ;;  # do nothing
+          *) PATH=${usrBin}:$PATH ;;
+        esac
+        export PATH
+      '';
+    }
+
+  ]);
+}

--- a/modules/home-manager/shared/fish.nix
+++ b/modules/home-manager/shared/fish.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+with lib;
+let
+  cfg = config.programs.fish;
+  username = config.home.username;
+
+  sysBin = "/nix/var/nix/profiles/default/bin";
+  usrBin =
+    "/nix/var/nix/profiles/per-user/${username}/home-manager/home-path/bin";
+
+in {
+  config = mkIf cfg.enable (mkMerge [
+
+    {
+      programs.fish.loginShellInit = ''
+        fish_add_path --move --prepend ${sysBin}
+        fish_add_path --move --prepend ${usrBin}
+      '';
+    }
+
+  ]);
+}

--- a/modules/home-manager/shared/zsh.nix
+++ b/modules/home-manager/shared/zsh.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }:
+with lib;
+let
+  cfg = config.programs.zsh;
+  username = config.home.username;
+
+  sysBin = "/nix/var/nix/profiles/default/bin";
+  usrBin =
+    "/nix/var/nix/profiles/per-user/${username}/home-manager/home-path/bin";
+in {
+  config = mkMerge [
+
+    (mkIf cfg.enable {
+      programs.zsh.initExtraFirst = ''
+        export -U PATH=${sysBin}''${PATH:+:$PATH}
+        export -U PATH=${usrBin}''${PATH:+:$PATH}
+      '';
+    })
+
+  ];
+}

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -41,8 +41,18 @@
           # An example of user environment. Change your username.
           ({ pkgs, lib, ... }: {
             home-manager.users."yourUsername" = {
+
               home.packages = with pkgs; [ exa ];
+
+              # enable at least one shell. as for any other program, see customizable options at:
+              # https://github.com/nix-community/home-manager/blob/master/modules/programs/<program>.nix
+              programs.zsh.enable = true;
+              # programs.fish.enable = true;
+              # programs.bash.enable = true;
+
+              # create some custom dot-files on your user's home.
               home.file.".config/foo".text = "bar";
+
               programs.git = {
                 enable = true;
                 userName = "Your Name";


### PR DESCRIPTION
Looks like there's been some
[issues](https://github.com/LnL7/nix-darwin/issues/122) involving
proper PATH initialization when combining home-manager and nix-darwin.

This patch adds the bin directories from system's default profile and
user's home-manager profile
into PATH at shell-init. For this to work, the user configuration has to
have a shell enabled. eg, `program.zsh.enable = true`.

Updated `minimal/flake.nix` and added a comment about where to look for
home-manager programs options.

Fixes #6.